### PR TITLE
Cursor improvements (Resolve #2)

### DIFF
--- a/spec/cursor_spec.ls
+++ b/spec/cursor_spec.ls
@@ -171,3 +171,21 @@ describe "cursor" (_) ->
 
       expect raw-tom-b .to-be .raw-tom-a
       expect observer .not.to-have-been-called!
+
+    it "serialises recursive updates" ->
+      data = cursor raw-data
+      age = data.get \person.age
+
+      trace = []
+
+      age.on-change ->
+        return if it > 40
+
+        trace.push it
+        age.update -> it + 1
+        trace.push it
+
+      age.update -> it + 1
+
+      expect trace .to-equal [36, 36, 37, 37, 38, 38, 39, 39, 40, 40]
+


### PR DESCRIPTION
This makes the cursor more resilient to infinite update loops and the API more consistent in terms of what data it passes to consumers when
### TODO
- [x] `deref`, `update` and `on-change` all return plain JavaScript objects
- [x] only update and notify listeners when value actually changes
- [x] queue updates performed when updating (instead of recursively stacking them)
- [x] provide access to the raw immutable data structure backing the cursor in a `raw` method
