### PR TITLE
Application.ls Refactoring

### DIFF
--- a/src/application.ls
+++ b/src/application.ls
@@ -1,67 +1,93 @@
 require! <[ bluebird ./routes ./cursor ./dom ./server-rendering ]>
+
 {span} = dom
-
-app-component = React.create-factory React.create-class do
-  display-name: 'reflex-application'
-
-  get-initial-state: ->
-    component: @props.component
-    context: @props.context
-    app-state: @props.initial-state
-
-  render: ->
-    if @state.component
-      React.create-element that, context: @state.context, app-state: @state.app-state
-    else
-      span "Page not found."
 
 module.exports =
   # define an application instance
   create: (config) ->
     do
-      # start the application
+      state: null # Our state cursor holder
+      _routes: config.routes! # A reference to our parsed routes.
+
+      # Allow definition of a different mount point.
+      root: if process.env.REFLEX_ENV is 'browser' => (config.root or document.get-element-by-id 'application' or document.body) else => void
+
+      # Root component layout
+      type: React.create-class do
+        display-name: 'reflex-application'
+
+        render: ->
+          if @props.component then
+            React.create-element that.deref!, @props{state, context}
+          else
+            span "Page not found."
+
+      # Create an instance of the root component element
+      element: -> React.create-element @type, do
+        component: @state.get 'component'
+        context: @state.get 'context'
+        state: @state.get 'state'
+
+      # Mount the application to the root node
+      mount: -> React.render @element!, @root
+
+      # Common state loader/initialiser
+      # Returns a promise with state.
+      initialise: (path=(location.pathname + location.search + location.hash)) ->
+        new bluebird (res, rej) ~>
+          # Load initial state (env dependent)
+          unless process.env.REFLEX_ENV is 'browser' and state = JSON.parse @root.get-attribute 'data-reflex-app-state'
+            state = config.get-initial-state! or {}
+
+          # Resolve routes before getting into async stuff..
+          [component, context, route-init] = routes.resolve path, @_routes
+
+          new bluebird (res, rej) -> (config.start or ((a, b) -> b a)) state, res
+          .then (state) ->
+            new bluebird (res, rej) -> (route-init or ((a, b) -> b a)) state, res
+            .then (state)
+              # And finally, send state and route data to be rendered/mounted/processed.
+              res cursor {state, component, context}
+
+      # clientside loader
       start: ->
-        path = (location.pathname + location.search + location.hash)
-        root-dom-node = document.get-element-by-id "application"
+        @initialise!
+        .then (state) ~>
+          @state = state
 
-        server-state = JSON.parse root-dom-node.get-attribute 'data-reflex-app-state'
-        initial-state = cursor (server-state or config.get-initial-state!)
+          # Initialise clientside routing
+          routes.start @_routes, (component, context, init) ~>
+            # When a route changes, update the state to reflect the new route
+            @state.update (data) ->
+              data.state = init data.state if init
+              data import {component, context}
 
-        [route-component, context, _] = routes.resolve path, config.routes!
-        root-element = app-component initial-state: initial-state, component: route-component, context: context
+          # Tell application to rerender on state change.
+          @state.on-change ~>
+            @mount!
 
-        config.start initial-state, (->)
-
-        root = React.render root-element, root-dom-node
-
-        initial-state.on-change -> root.set-state app-state: initial-state
-        routes.start config.routes!, root, initial-state
+          # Then mount once clientside!
+          @mount!
 
       # render a particular route to string
       # returns a promise of [state, body]
       render: (path) ->
-        new bluebird (res, rej) ->
-          initial-state = cursor config.get-initial-state!
-
-          [route-component, context, route-init] = routes.resolve path, config.routes!
-          root-element = app-component initial-state: initial-state, component: route-component, context: context
-
-          config.start initial-state, ->
-            return res [initial-state.deref!, React.render-to-string root-element] unless route-init
-
-            route-init initial-state, context, ->
-              res [initial-state.deref!, React.render-to-string root-element]
+        new bluebird (res, rej) ~>
+          @initialise path
+          .then (state) ~>
+            console.log state
+            return res [state.get 'state' .deref!, React.render-to-string @element!]
 
       # process a form from a particular route and render to string
       # returns a promise of [state, body, location]
       process-form: (path, post-data) ->
-        new bluebird (res, rej) ->
+        new bluebird (res, rej) ~>
           initial-state = cursor config.get-initial-state!
 
           [route-component, context, route-init] = routes.resolve path, config.routes!
-          root-element = app-component initial-state: initial-state, component: route-component, context: context
+          root-element = React.create-element @type, initial-state: initial-state, component: route-component, context: context
 
-          config.start initial-state, ->
+        config.start initial-state, ->
             return res server-rendering.process-form root-element, initial-state, post-data, path unless route-init
 
             route-init initial-state, context, ->

--- a/src/application.ls
+++ b/src/application.ls
@@ -2,11 +2,14 @@ require! <[ bluebird ./routes ./cursor ./dom ./server-rendering ]>
 
 {span} = dom
 
+not-found = span "Page not found."
+
 module.exports =
   # define an application instance
   create: (config) ->
     do
       state: null # Our state cursor holder
+      component: null
       _routes: config.routes! # A reference to our parsed routes.
 
       # Allow definition of a different mount point.
@@ -18,13 +21,13 @@ module.exports =
 
         render: ->
           if @props.component then
-            React.create-element that.deref!, @props{app-state, context}
+            React.create-element that, @props{app-state, context}
           else
-            span "Page not found."
+            not-found
 
       # Create an instance of the root component element
       element: (state = @state) -> React.create-element @type, do
-        component: state.get 'component'
+        component: @component
         context: state.get 'context'
         app-state: state.get 'appState'
 
@@ -45,19 +48,20 @@ module.exports =
           new bluebird (res, rej) ->
             # Run app initialiser if it exists (asynchronously)
             if config.start then config.start app-state, res else res app-state
-          .then (app-state) ->
+          .then (app-state) ~>
             # Then run route initialiser if it exists (asynchronously)
-            new bluebird (res, rej) ->
+            new bluebird (res, rej) ~>
               if route-init then route-init app-state, res else res app-state
-            .then (app-state) ->
-              # And finally, send state and route data to be rendered/mounted/processed.
-              res cursor {app-state, component, context}
+            .then (app-state) ~>
+              # And finally, set state and component, and resolve the promise!
+              @state = cursor {app-state, context}
+              @component = component
+              res!
 
       # clientside loader
       start: ->
         @initialise!
-        .then (state) ~>
-          @state = state
+        .then ~>
           # Initialise clientside routing
           routes.start @_routes, (component, context, init) ~>
             # When a route changes, update the state to reflect the new route
@@ -65,12 +69,11 @@ module.exports =
               state = @state.get 'appState' .deref!
               if init then init state, res else res state
             .then (app-state) ~>
+              @component = component
               @state.update (data) ->
-                data import {app-state, component, context}
+                data import {app-state, context}
 
-          # Tell application to rerender on state change.
-          @state.on-change ~>
-            @mount!
+          @state.on-change ~> @mount!
 
           # Then mount once clientside!
           @mount!
@@ -80,14 +83,13 @@ module.exports =
       render: (path) ->
         new bluebird (res, rej) ~>
           @initialise path
-          .then (state) ~>
-            return res [state.get 'appState' .deref!, React.render-to-string @element state]
+          .then ~>
+            return res [@state.get 'appState' .deref!, React.render-to-string @element!]
 
       # process a form from a particular route and render to string
       # returns a promise of [state, body, location]
       process-form: (path, post-data) ->
         new bluebird (res, rej) ~>
           @initialise path
-          .then (state) ~>
-          @state = state
-          res server-rendering.process-form @element!, state, post-data, path
+          .then ~>
+          res server-rendering.process-form @element!, @state, post-data, path

--- a/src/bundler.ls
+++ b/src/bundler.ls
@@ -30,7 +30,6 @@ exports.bundle = (paths, watch, changed) ->
       root: path.join paths.reflex.abs, 'node_modules'
       fallback: path.join paths.app.abs, 'node_modules'
 
-
     plugins: [ new webpack.DefinePlugin 'process.env': browser-env ]
 
     module:

--- a/src/routes.ls
+++ b/src/routes.ls
@@ -59,12 +59,12 @@ module.exports =
   navigate: (path) ->
     page.show path
 
-  start: (configs, root-component, app-state) ->
+  start: (configs, load) ->
     configs |> each (config) ->
       page.callbacks.push config.route.middleware (ctx) ->
         context = context-from-url(ctx.canonical-path, ctx.params)
 
-        root-component.set-state component: config.component, context: context
+        load config.component, context, config.init
         window.scroll-to 0, 0
 
         # call the route callback

--- a/src/routes.ls
+++ b/src/routes.ls
@@ -67,9 +67,6 @@ module.exports =
         load config.component, context, config.init
         window.scroll-to 0, 0
 
-        # call the route callback
-        config.init(app-state, context, ->) if config.init
-
     # only start client-side routing if pushState is available
     page.start! if (typeof window.history.replace-state isnt 'undefined')
     @running = true


### PR DESCRIPTION
- Promisified route and state initialisers and running them in sequence.
- Collapsed all the state initialisers into one, to DRY the code in each of the 3 render methods an Application has (form, to-string, clientside).
- No longer use component state (`setState`)
All in all, easier to read and fixes https://github.com/redbadger/reflex/issues/22