### PR TITLE
Asynchronous on change handlers

### DIFF
--- a/src/cursor.ls
+++ b/src/cursor.ls
@@ -6,6 +6,9 @@ require! 'bluebird'
 UpdateTransaction = !->
   @promises = []
 
+is-promise = ->
+  it and it.then and typeof! it.then is 'Function'
+
 # wraps array in a cursor
 array-cursor = (root, data, len, path) ->
   array = [0 til len] |> map ->
@@ -41,7 +44,7 @@ notify-listeners = (listeners, transactions, path, new-data) !->
 
       maybe-promise = it(payload)
 
-      if maybe-promise and maybe-promise.then
+      if is-promise maybe-promise
         transactions |> each -> it.promises.push maybe-promise
 
 flush-updates = (updates) ->

--- a/src/cursor.ls
+++ b/src/cursor.ls
@@ -1,5 +1,10 @@
 Immutable = require 'immutable'
+require! 'bluebird'
+
 {map, take, reverse, each, join, split, is-type, empty} = require 'prelude-ls'
+
+UpdateTransaction = !->
+  @promises = []
 
 # wraps array in a cursor
 array-cursor = (root, data, len, path) ->
@@ -10,6 +15,7 @@ array-cursor = (root, data, len, path) ->
   array._root = root or this
   array._data = if data then Immutable.fromJS(data) else null
   array._listeners = {}
+  array._transactions = []
   array._updates = []
 
   # Support all the cursor API
@@ -20,7 +26,7 @@ array-cursor = (root, data, len, path) ->
 object-cursor = (root, data, path) ->
   new Cursor root, data, path
 
-notify-listeners = (listeners, path, new-data) !->
+notify-listeners = (listeners, transactions, path, new-data) !->
   paths = [0 to path.length]
   |> map (-> path |> take it)
   |> reverse
@@ -33,7 +39,10 @@ notify-listeners = (listeners, path, new-data) !->
       payload = new-data.get-in path
       payload .= toJS! if payload.toJS
 
-      it(payload)
+      maybe-promise = it(payload)
+
+      if maybe-promise and maybe-promise.then
+        transactions |> each -> it.promises.push maybe-promise
 
 flush-updates = (updates) ->
   while updates.length > 0
@@ -60,13 +69,14 @@ perform-update = (cursor, update) ->
   cursor._root._swap new-data
 
   # Notify about the change
-  notify-listeners cursor._root._listeners, cursor._path, new-data
+  notify-listeners cursor._root._listeners, cursor._root._transactions, cursor._path, new-data
 
 Cursor = (root, data, path) ->
   @_path = path
   @_root = root or this
   @_data = if data then Immutable.fromJS(data) else null
   @_listeners = {}
+  @_transactions = []
   @_updates = []
 
   this
@@ -96,7 +106,7 @@ Cursor.prototype.update = (cbk) ->
   updates.push [this, cbk]
   return unless updates.length < 2
 
-  while updates.length > 0
+  until empty updates
     [cursor, update] = updates[0]
     perform-update cursor, update
 
@@ -111,6 +121,20 @@ Cursor.prototype.on-change = (cbk) ->
   key = join '.', @_path
   @_root._listeners[key] ||= []
   @_root._listeners[key].push cbk
+
+Cursor.prototype.start-transaction = ->
+  t = new UpdateTransaction!
+  @_root._transactions.push t
+
+  t
+
+Cursor.prototype.end-transaction = (transaction) ->
+  i = @_root._transactions.index-of transaction
+  throw new Error "Transaction isn't running" if i < 0
+
+  return bluebird.resolve! if empty transaction.promises
+
+  bluebird.all transaction.promises
 
 module.exports = (data) ->
   if is-type 'Array', data

--- a/src/server-rendering.ls
+++ b/src/server-rendering.ls
@@ -72,6 +72,8 @@ submit-form = (form) ->
   form.props.on-submit fake-event form
   ReactUpdates.flushBatchedUpdates!
 
+# Processes a form server-side, returns a redirect location or null
+# FIXME should we deal with the redirect in application.ls?
 process-form = (root-element, initial-state, post-data, path) ->
   configure-react!
   reset-redirect!
@@ -96,12 +98,9 @@ process-form = (root-element, initial-state, post-data, path) ->
 
   # end of magic
 
-  return [null, null, that] if redirect-location
+  return that if redirect-location
 
-  state = initial-state.deref!
-  body = React.render-to-string root-element
-
-  [state, body, null]
+  null
 
 reset-redirect = ->
   redirect-location := null

--- a/src/server-rendering.ls
+++ b/src/server-rendering.ls
@@ -90,10 +90,8 @@ process-form = (root-element, initial-state, post-data, path) ->
 
   [form, inputs] = extract-elements path, post-data, instance
 
-  # trigger on-change handlers
+  # trigger handlers
   change-inputs inputs, post-data
-
-  # trigger on-submit handler
   submit-form form
 
   # end of magic

--- a/src/server.ls
+++ b/src/server.ls
@@ -21,14 +21,14 @@ module.exports = (options=defaults) ->
   app = options.app or require options.paths.app.rel
 
   get = (req, res) ->
-    console.log "GET ", req.original-url
+    console.log "GET", req.original-url
     reflex-get app, req.original-url, options
     .then ->
       res.send it
 
   post = (req, res) ->
     post-data = req.body
-    console.log "POST ", req.original-url, post-data
+    console.log "POST", req.original-url, post-data
 
     reflex-post app, req.original-url, post-data, options
     .spread (status, headers, body) ->


### PR DESCRIPTION
Add support for `on-change` on a cursor to return a promise. Anyone can start an update transaction with `start-transaction`. Any updates to the cursor in between that call and a subsequent call to `end-transaction` passing the transaction obtained from `start-transaction` may trigger one or more `on-change` handlers. Those handlers may rely on asynchronous calls. If they do, they can now return a promise, which they resolve when their asynchronous behaviour is done. All promises returned by the `on-change` handlers are collected on all running transactions and the call to `end-transaction` returns a promise waiting for all of them to finish (using bluebird's `.all`). If no change handlers were registered or no promises were returned the `end-transaction` call will return a resolved promise.

This is useful in multiple scenarios and simplifies dealing with asynchronous calls in state observers. For instance, using this, Reflex can wait for even asynchronous change handlers to finish what they are doing before rendering server side. In the same way, application initialisation can trigger an async on-change with a state update and Reflex will wait until it is finished before rendering (no need for an explicit `done` callback in `start` or route initialisation). 

### To Do

- [x] basic transaction logic
- [x] better check for promise
- [x] integrate into server-side rendering