### PR TITLE
App-specific Bundle Configuration

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,4 +1,15 @@
 #!/usr/bin/env node
-var server = require('../lib/server');
-var app = server().start();
+var fs = require('fs');
+var path = require('path');
+var server;
 
+try {
+  var localServer = fs.statSync(path.join(path.resolve('.'), 'server.js'));
+  if (localServer.isFile()) {
+    server = require(path.join(path.resolve('.'), 'server.js'));
+  }
+}
+
+catch (e) {
+  server = require('../lib/server')().start();
+}

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -1,73 +1,33 @@
 (function(){
-  var webpack, path, webpackDevServer, ref$, Obj, keys;
+  var webpack, path, webpackDevServer, fs, deepExtend, reflexConfig, ref$, Obj, keys;
   webpack = require('webpack');
   path = require('path');
   webpackDevServer = require('webpack-dev-server');
+  fs = require('fs');
+  deepExtend = require('deep-extend');
+  reflexConfig = require('./webpack.config');
   ref$ = require('prelude-ls'), Obj = ref$.Obj, keys = ref$.keys;
-  exports.bundle = function(paths, watch, changed){
-    var entry, browserEnv, config, bundler, lastBuild, server;
-    entry = require.resolve(paths.app.abs);
-    browserEnv = clone$(process.env);
-    browserEnv.REFLEX_ENV = 'browser';
-    browserEnv = Obj.map(JSON.stringify)(
-    browserEnv);
-    config = {
-      entry: ['./' + path.basename(entry)],
-      context: path.dirname(entry),
-      output: {
-        libraryTarget: 'var',
-        library: 'Application',
-        path: path.join(paths.app.abs, paths['public']),
-        filename: 'app.js'
-      },
-      resolve: {
-        root: path.join(paths.app.abs, 'node_modules'),
-        fallback: path.join(paths.reflex.abs, 'node_modules'),
-        extensions: ['', '.ls', '.js', '.jsx']
-      },
-      resolveLoader: {
-        root: path.join(paths.reflex.abs, 'node_modules'),
-        fallback: path.join(paths.app.abs, 'node_modules')
-      },
-      plugins: [new webpack.DefinePlugin({
-        'process.env': browserEnv
-      })],
-      module: {
-        preLoaders: [{
-          test: /\.ls$/,
-          loader: 'livescript-loader'
-        }],
-        loaders: [],
-        postLoaders: []
+  exports.bundle = function(options, onChange){
+    var config, file, appConfig, bundler, lastBuild, server;
+    config = reflexConfig(options);
+    try {
+      file = fs.statSync(path.join(options.paths.app.abs, 'webpack.config.js'));
+      if (file.isFile()) {
+        appConfig = require(path.join(options.paths.app.rel, 'webpack.config.js'));
+        config = deepExtend(config, appConfig);
       }
-    };
-    if (process.env.NODE_ENV === 'production') {
-      config.plugins.push(new webpack.optimize.DedupePlugin());
-      config.plugins.push(new webpack.optimize.UglifyJsPlugin());
-    }
-    if (watch) {
-      config.entry.unshift('webpack/hot/dev-server');
-      config.entry.unshift('webpack-dev-server/client?http://localhost:3001');
-      config.output.publicPath = 'http://localhost:3001/';
-      config.module.loaders.push({
-        test: /\.(?:js|jsx|ls)$/,
-        loader: 'react-hot',
-        exclude: /node_modules/
-      });
-      config.plugins.push(new webpack.HotModuleReplacementPlugin());
-      config.plugins.push(new webpack.NoErrorsPlugin());
-    }
+    } catch (e$) {}
     bundler = webpack(config);
-    if (watch) {
+    if (options.watch) {
       lastBuild = null;
       bundler.plugin('done', function(stats){
         var diff;
-        diff = keys(
+        diff = onChange(
+        keys(
         Obj.filter((function(it){
           return it > lastBuild;
         }))(
-        stats.compilation.fileTimestamps));
-        changed(diff);
+        stats.compilation.fileTimestamps)));
         return lastBuild = stats.endTime;
       });
       bundler.plugin('error', function(err){
@@ -75,21 +35,17 @@
       });
       server = new webpackDevServer(bundler, {
         filename: 'app.js',
-        contentBase: path.join(paths.app.abs, paths['public']),
+        contentBase: path.join(options.paths.app.abs, options.paths['public']),
         hot: true,
         quiet: true,
         noInfo: true,
         watchDelay: 200
       });
-      return server.listen(3001, 'localhost');
+      return server.listen(options.webpackPort, 'localhost');
     } else {
       return bundler.run(function(err, stats){
         return console.log('Bundled app.js');
       });
     }
   };
-  function clone$(it){
-    function fun(){} fun.prototype = it;
-    return new fun;
-  }
 }).call(this);

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -8,7 +8,7 @@
   reflexConfig = require('./webpack.config');
   ref$ = require('prelude-ls'), Obj = ref$.Obj, keys = ref$.keys;
   exports.bundle = function(options, onChange){
-    var config, file, appConfig, message, bundler, lastBuild, server;
+    var config, file, appConfig, bundler, lastBuild, server;
     config = reflexConfig(options);
     try {
       file = fs.statSync(path.join(path.resolve(options.paths.app.abs), 'webpack.config.js'));
@@ -16,10 +16,7 @@
         appConfig = require(path.join(options.paths.app.abs, 'webpack.config.js'));
         config = deepExtend(config, appConfig);
       }
-    } catch (e$) {
-      message = e$.message;
-      console.error(message);
-    }
+    } catch (e$) {}
     bundler = webpack(config);
     if (options.watch) {
       lastBuild = null;

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -8,15 +8,18 @@
   reflexConfig = require('./webpack.config');
   ref$ = require('prelude-ls'), Obj = ref$.Obj, keys = ref$.keys;
   exports.bundle = function(options, onChange){
-    var config, file, appConfig, bundler, lastBuild, server;
+    var config, file, appConfig, message, bundler, lastBuild, server;
     config = reflexConfig(options);
     try {
-      file = fs.statSync(path.join(options.paths.app.abs, 'webpack.config.js'));
+      file = fs.statSync(path.join(path.resolve(options.paths.app.abs), 'webpack.config.js'));
       if (file.isFile()) {
-        appConfig = require(path.join(options.paths.app.rel, 'webpack.config.js'));
+        appConfig = require(path.join(options.paths.app.abs, 'webpack.config.js'));
         config = deepExtend(config, appConfig);
       }
-    } catch (e$) {}
+    } catch (e$) {
+      message = e$.message;
+      console.error(message);
+    }
     bundler = webpack(config);
     if (options.watch) {
       lastBuild = null;
@@ -37,8 +40,8 @@
         filename: 'app.js',
         contentBase: path.join(options.paths.app.abs, options.paths['public']),
         hot: true,
-        quiet: true,
-        noInfo: true,
+        quiet: !options.debug,
+        noInfo: !options.debug,
         watchDelay: 200
       });
       return server.listen(options.webpackPort, 'localhost');

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,5 @@
 (function(){
-  var express, fs, path, jade, bluebird, bodyParser, bundler, ref$, each, values, filter, find, flatten, map, first, __template, readFile, defaults, reflexGet, reflexPost, reflexInterp, layoutRender;
+  var express, fs, path, jade, bluebird, bodyParser, bundler, deepExtend, ref$, each, values, filter, find, flatten, map, first, __template, readFile, defaults, reflexGet, reflexPost, reflexInterp, layoutRender;
   express = require('express');
   fs = require('fs');
   path = require('path');
@@ -7,6 +7,7 @@
   bluebird = require('bluebird');
   bodyParser = require('body-parser');
   bundler = require('./bundler');
+  deepExtend = require('deep-extend');
   ref$ = require('prelude-ls'), each = ref$.each, values = ref$.values, filter = ref$.filter, find = ref$.find, flatten = ref$.flatten, map = ref$.map, first = ref$.first;
   __template = jade.compileFile(path.join(__dirname, 'index.jade'));
   readFile = bluebird.promisify(fs.readFile);
@@ -25,12 +26,14 @@
         rel: path.relative(path.resolve('.'), path.dirname(require.resolve("../package.json")))
       },
       'public': 'dist'
-    }
+    },
+    watch: process.env.NODE_ENV !== 'production',
+    webpackPort: 3001
   };
   module.exports = function(options){
     var app, get, post;
     options == null && (options = {});
-    options = import$(defaults, options);
+    options = deepExtend(defaults, options);
     each(require)(
     options.dependencies);
     app = options.app || require(options.paths.app.rel);
@@ -55,7 +58,7 @@
         server = express().use("/" + options.paths['public'], express['static'](path.join(options.paths.app.abs, options.paths['public']))).use(bodyParser.urlencoded({
           extended: false
         })).get('*', get).post('*', post);
-        bundler.bundle(options.paths, options.environment === 'development', function(ids){
+        bundler.bundle(options, function(ids){
           var done, id, parents;
           done = [];
           while (id = first(ids)) {
@@ -93,7 +96,8 @@
             console.log('App is listening on', listener.address().port);
             return cb(err, {
               server: server,
-              listener: listener
+              listener: listener,
+              options: options
             });
           });
         } else {
@@ -103,7 +107,8 @@
               console.log('App is listening on', listener.address().port);
               return res({
                 server: server,
-                listener: listener
+                listener: listener,
+                options: options
               });
             });
           });
@@ -150,11 +155,6 @@
       throw new Error('Template not found');
     });
   };
-  function import$(obj, src){
-    var own = {}.hasOwnProperty;
-    for (var key in src) if (own.call(src, key)) obj[key] = src[key];
-    return obj;
-  }
   function in$(x, xs){
     var i = -1, l = xs.length >>> 0;
     while (++i < l) if (x === xs[i]) return true;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,5 @@
 (function(){
-  var express, fs, path, jade, bluebird, bodyParser, bundler, LiveScript, ref$, each, values, filter, find, flatten, map, first, __template, readFile, defaults, reflexGet, reflexPost, reflexInterp, layoutRender;
+  var express, fs, path, jade, bluebird, bodyParser, bundler, ref$, each, values, filter, find, flatten, map, first, __template, readFile, defaults, reflexGet, reflexPost, reflexInterp, layoutRender;
   express = require('express');
   fs = require('fs');
   path = require('path');
@@ -7,11 +7,11 @@
   bluebird = require('bluebird');
   bodyParser = require('body-parser');
   bundler = require('./bundler');
-  LiveScript = require('LiveScript');
   ref$ = require('prelude-ls'), each = ref$.each, values = ref$.values, filter = ref$.filter, find = ref$.find, flatten = ref$.flatten, map = ref$.map, first = ref$.first;
   __template = jade.compileFile(path.join(__dirname, 'index.jade'));
   readFile = bluebird.promisify(fs.readFile);
   defaults = {
+    dependencies: [],
     environment: process.env.NODE_ENV || 'development',
     port: 3000,
     paths: {
@@ -29,7 +29,10 @@
   };
   module.exports = function(options){
     var app, get, post;
-    options == null && (options = defaults);
+    options == null && (options = {});
+    options = import$(defaults, options);
+    each(require)(
+    options.dependencies);
     app = options.app || require(options.paths.app.rel);
     get = function(req, res){
       console.log("GET ", req.originalUrl);
@@ -147,6 +150,11 @@
       throw new Error('Template not found');
     });
   };
+  function import$(obj, src){
+    var own = {}.hasOwnProperty;
+    for (var key in src) if (own.call(src, key)) obj[key] = src[key];
+    return obj;
+  }
   function in$(x, xs){
     var i = -1, l = xs.length >>> 0;
     while (++i < l) if (x === xs[i]) return true;

--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -1,0 +1,65 @@
+(function(){
+  var path, webpack, Obj, config;
+  path = require('path');
+  webpack = require('webpack');
+  Obj = require('prelude-ls').Obj;
+  config = function(options){
+    var paths, watch, entry, browserEnv, conf;
+    paths = options.paths;
+    watch = options.watch;
+    entry = require.resolve(options.paths.app.rel);
+    browserEnv = clone$(process.env);
+    browserEnv.REFLEX_ENV = 'browser';
+    browserEnv = Obj.map(JSON.stringify)(
+    browserEnv);
+    conf = {
+      entry: ['./' + path.basename(entry)],
+      context: path.dirname(entry),
+      output: {
+        libraryTarget: 'var',
+        library: 'Application',
+        path: path.join(paths.app.abs, paths['public']),
+        filename: 'app.js'
+      },
+      resolve: {
+        root: path.join(paths.app.abs, 'node_modules'),
+        fallback: path.join(paths.reflex.abs, 'node_modules'),
+        extensions: ['', '.js', '.jsx']
+      },
+      resolveLoader: {
+        root: path.join(paths.reflex.abs, 'node_modules'),
+        fallback: path.join(paths.app.abs, 'node_modules')
+      },
+      plugins: [new webpack.DefinePlugin({
+        'process.env': browserEnv
+      })],
+      module: {
+        preLoaders: [],
+        loaders: [],
+        postLoaders: []
+      }
+    };
+    if (options.environment === 'production') {
+      conf.plugins.push(new webpack.optimize.DedupePlugin());
+      conf.plugins.push(new webpack.optimize.UglifyJsPlugin());
+    }
+    if (options.watch) {
+      conf.entry.unshift('webpack/hot/dev-server');
+      conf.entry.unshift('webpack-dev-server/client?http://localhost:3001');
+      conf.output.publicPath = 'http://localhost:3001/';
+      conf.module.loaders.push({
+        test: /\.(?:js|jsx)$/,
+        loader: 'react-hot',
+        exclude: /node_modules/
+      });
+      conf.plugins.push(new webpack.HotModuleReplacementPlugin());
+      conf.plugins.push(new webpack.NoErrorsPlugin());
+    }
+    return conf;
+  };
+  module.exports = config;
+  function clone$(it){
+    function fun(){} fun.prototype = it;
+    return new fun;
+  }
+}).call(this);

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
   },
   "dependencies": {
     "bluebird": "^2.3.11",
-    "envify-loader": "^0.1.0",
     "body-parser": "^1.10.1",
+    "deep-extend": "^0.3.2",
+    "envify-loader": "^0.1.0",
     "express": "^4.10.6",
     "immutable": "^3.4.1",
     "jade": "^1.8.2",

--- a/src/bundler.ls
+++ b/src/bundler.ls
@@ -12,8 +12,6 @@ exports.bundle = (options, on-change) ->
     if file.is-file!
       app-config = require path.join(options.paths.app.abs, 'webpack.config.js')
       config := deep-extend config, app-config
-  catch {message}
-    console.error message
 
   # Initialise the bundle
   bundler = webpack config

--- a/src/bundler.ls
+++ b/src/bundler.ls
@@ -8,10 +8,12 @@ exports.bundle = (options, on-change) ->
 
   # Deep-merge application config into reflex default config.
   try
-    file = fs.stat-sync path.join(options.paths.app.abs, 'webpack.config.js')
+    file = fs.stat-sync path.join(path.resolve(options.paths.app.abs), 'webpack.config.js')
     if file.is-file!
-      app-config = require path.join(options.paths.app.rel, 'webpack.config.js')
+      app-config = require path.join(options.paths.app.abs, 'webpack.config.js')
       config := deep-extend config, app-config
+  catch {message}
+    console.error message
 
   # Initialise the bundle
   bundler = webpack config
@@ -32,8 +34,8 @@ exports.bundle = (options, on-change) ->
       filename: 'app.js'
       content-base: path.join options.paths.app.abs, options.paths.public
       hot: true # Enable hot loading
-      quiet: true
-      no-info: true
+      quiet: !options.debug
+      no-info: !options.debug
       watch-delay: 200
 
     server.listen options.webpack-port, 'localhost'

--- a/src/bundler.ls
+++ b/src/bundler.ls
@@ -1,74 +1,27 @@
-require! <[ webpack path webpack-dev-server ]>
+require! <[ webpack path webpack-dev-server fs deep-extend ]>
+reflex-config = require './webpack.config'
 
 {Obj, keys} = require 'prelude-ls'
 
-exports.bundle = (paths, watch, changed) ->
-  entry = require.resolve paths.app.abs
+exports.bundle = (options, on-change) ->
+  config = reflex-config options
 
-  browser-env = ^^process.env
-  browser-env.REFLEX_ENV = 'browser'
-  browser-env = browser-env |> Obj.map JSON.stringify
-
-  # Basic configuration
-  config =
-    entry: [ './' + path.basename entry ]
-
-    context: path.dirname entry
-
-    output:
-      library-target: 'var'
-      library: 'Application'
-      path: path.join paths.app.abs, paths.public
-      filename: 'app.js'
-
-    resolve:
-      root: path.join paths.app.abs, 'node_modules'
-      fallback: path.join paths.reflex.abs, 'node_modules'
-      extensions: [ '', '.ls', '.js', '.jsx' ]
-
-    resolve-loader:
-      root: path.join paths.reflex.abs, 'node_modules'
-      fallback: path.join paths.app.abs, 'node_modules'
-
-
-    plugins: [ new webpack.DefinePlugin 'process.env': browser-env ]
-
-    module:
-      pre-loaders: [
-        * test: /\.ls$/
-          loader: 'livescript-loader'
-      ]
-      loaders: []
-      post-loaders: []
-
-  # Optimise for production.
-  if process.env.NODE_ENV is 'production'
-    config.plugins.push new webpack.optimize.DedupePlugin!
-    config.plugins.push new webpack.optimize.UglifyJsPlugin!
-
-  # Enable HMR if watching.
-  if watch
-    config.entry.unshift 'webpack/hot/dev-server'
-    config.entry.unshift 'webpack-dev-server/client?http://localhost:3001'
-    config.output.public-path = 'http://localhost:3001/'
-    config.module.loaders.push do
-      test: /\.(?:js|jsx|ls)$/
-      loader: 'react-hot'
-      exclude: /node_modules/
-    config.plugins.push new webpack.HotModuleReplacementPlugin!
-    config.plugins.push new webpack.NoErrorsPlugin!
+  # Deep-merge application config into reflex default config.
+  try
+    file = fs.stat-sync path.join(options.paths.app.abs, 'webpack.config.js')
+    if file.is-file!
+      app-config = require path.join(options.paths.app.rel, 'webpack.config.js')
+      config := deep-extend config, app-config
 
   # Initialise the bundle
   bundler = webpack config
 
   # Just bundle or watch + serve via webpack-dev-server
-  if watch
-
+  if options.watch
     # Add a callback to server, passing changed files, to reload app code server-side.
     last-build = null
     bundler.plugin 'done', (stats) ->
-      diff = stats.compilation.file-timestamps |> Obj.filter (> last-build) |> keys
-      changed diff
+      diff = stats.compilation.file-timestamps |> Obj.filter (> last-build) |> keys |> on-change
       last-build := stats.end-time
 
     bundler.plugin 'error', (err) ->
@@ -77,13 +30,13 @@ exports.bundle = (paths, watch, changed) ->
     # Start the webpack dev server
     server = new webpack-dev-server bundler, do
       filename: 'app.js'
-      content-base: path.join paths.app.abs, paths.public
+      content-base: path.join options.paths.app.abs, options.paths.public
       hot: true # Enable hot loading
       quiet: true
       no-info: true
       watch-delay: 200
 
-    server.listen 3001, 'localhost'
+    server.listen options.webpack-port, 'localhost'
 
   else
     # Run once if watch is false

--- a/src/server.ls
+++ b/src/server.ls
@@ -1,10 +1,11 @@
-require! <[ express fs path jade bluebird body-parser ./bundler LiveScript ]>
+require! <[ express fs path jade bluebird body-parser ./bundler ]>
 {each, values, filter, find, flatten, map, first} = require 'prelude-ls'
 
 __template = jade.compile-file (path.join __dirname, 'index.jade')
 read-file = bluebird.promisify fs.read-file
 
 defaults =
+  dependencies: []
   environment: process.env.NODE_ENV or 'development'
   port: 3000
   paths:
@@ -17,7 +18,9 @@ defaults =
       rel: path.relative (path.resolve '.'), (path.dirname require.resolve "../package.json")
     public: 'dist'
 
-module.exports = (options=defaults) ->
+module.exports = (options={}) ->
+  options = defaults import options
+  options.dependencies |> each require
   app = options.app or require options.paths.app.rel
 
   get = (req, res) ->

--- a/src/webpack.config.ls
+++ b/src/webpack.config.ls
@@ -1,0 +1,61 @@
+require! <[ path webpack ]>
+{Obj} = require 'prelude-ls'
+
+# Basic configuration
+config = (options) ->
+  paths = options.paths
+  watch = options.watch
+  entry = require.resolve options.paths.app.rel
+
+  browser-env = ^^process.env
+  browser-env.REFLEX_ENV = 'browser'
+  browser-env = browser-env |> Obj.map JSON.stringify
+
+  conf =
+    entry: [ './' + path.basename entry ]
+
+    context: path.dirname entry
+
+    output:
+      library-target: 'var'
+      library: 'Application'
+      path: path.join paths.app.abs, paths.public
+      filename: 'app.js'
+
+    resolve:
+      root: path.join paths.app.abs, 'node_modules'
+      fallback: path.join paths.reflex.abs, 'node_modules'
+      extensions: [ '', '.js', '.jsx' ]
+
+    resolve-loader:
+      root: path.join paths.reflex.abs, 'node_modules'
+      fallback: path.join paths.app.abs, 'node_modules'
+
+    plugins: [ new webpack.DefinePlugin 'process.env': browser-env ]
+
+    module:
+      pre-loaders: []
+      loaders: []
+      post-loaders: []
+
+  # Optimise for production.
+  if options.environment is 'production'
+    conf.plugins.push new webpack.optimize.DedupePlugin!
+    conf.plugins.push new webpack.optimize.UglifyJsPlugin!
+
+  # Enable HMR if watching.
+  if options.watch
+    conf.entry.unshift 'webpack/hot/dev-server'
+    conf.entry.unshift 'webpack-dev-server/client?http://localhost:3001'
+    conf.output.public-path = 'http://localhost:3001/'
+    conf.module.loaders.push do
+      test: /\.(?:js|jsx)$/
+      loader: 'react-hot'
+      exclude: /node_modules/
+    conf.plugins.push new webpack.HotModuleReplacementPlugin!
+    conf.plugins.push new webpack.NoErrorsPlugin!
+
+  return conf
+
+
+module.exports = config


### PR DESCRIPTION
Allows use of a `webpack.config.js` file in an application root directory to specify custom loaders which will be merged with the default Reflex config.

ES6
```
module.exports = {
  module: {
    preLoaders: [
      {
        test: /\.(?:js|jsx)$/,
        exclude: /node_modules/,
        loader: 'babel-loader'
      }
    ]
  }
}
```

LiveScript
```
module.exports = {
  resolve: {
    extensions: ['', '.js', '.ls']
  },

  module: {
    preLoaders: [
      {
        test: /\.(?:ls)$/,
        exclude: /node_modules/,
        loader: 'livescript-loader'
      }
    ]
  }
}
```

You'll also have to specify server dependencies so it can `require` your app.

ES6
```
server = require('reflex/lib/server');
server({
  dependencies: [
    require.resolve('babel/register')
  ]
}).start();
```

LiveScript
```
server = require('reflex/lib/server');
server({
  dependencies: [
    require.resolve('LiveScript')
  ]
}).start();
```

The `reflex-server` binary will automatically read from this server.js file, so you don't need to change your start scripts (although you can if you want!)