### PR TITLE
Switch from file based rendering to a user provided template function

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -66,7 +66,9 @@
             routeInit(appState, context);
           }
           return appState.endTransaction(transaction).then(function(){
-            return [appState.deref(), React.renderToString(rootElement)];
+            var meta;
+            meta = serverRendering.routeMetadata(rootElement, appState);
+            return [meta, appState.deref(), React.renderToString(rootElement)];
           });
         },
         processForm: function(path, postData){
@@ -85,9 +87,10 @@
           }
           location = serverRendering.processForm(rootElement, appState, postData, path);
           return appState.endTransaction(transaction).then(function(){
-            var body;
+            var meta, body;
+            meta = serverRendering.routeMetadata(rootElement, appState);
             body = !location ? React.renderToString(rootElement) : null;
-            return [appState.deref(), body, location];
+            return [meta, appState.deref(), body, location];
           });
         }
       };

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,5 +1,6 @@
 (function(){
-  var page, ref$, splitAt, drop, split, map, pairsToObj, each, find, splitUrl, parseQuery, contextFromUrl, slice$ = [].slice;
+  var domUtils, page, ref$, splitAt, drop, split, map, pairsToObj, each, find, splitUrl, parseQuery, contextFromUrl, slice$ = [].slice;
+  domUtils = require('./virtual-dom-utils');
   page = require('page');
   ref$ = require('prelude-ls'), splitAt = ref$.splitAt, drop = ref$.drop, split = ref$.split, map = ref$.map, pairsToObj = ref$.pairsToObj, each = ref$.each, find = ref$.find;
   splitUrl = function(url){
@@ -69,8 +70,12 @@
           rootComponent.setState({
             component: config.component,
             context: context
+          }, function(){
+            var title;
+            title = domUtils.routeMetadata(rootComponent).title;
+            document.title = title;
+            return window.scrollTo(0, 0);
           });
-          window.scrollTo(0, 0);
           if (config.init) {
             return config.init(appState, context);
           }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -72,7 +72,7 @@
           });
           window.scrollTo(0, 0);
           if (config.init) {
-            return config.init(appState, context, function(){});
+            return config.init(appState, context);
           }
         }));
       })(

--- a/lib/server-rendering.js
+++ b/lib/server-rendering.js
@@ -1,10 +1,10 @@
 (function(){
-  var ref$, difference, filter, first, keys, Obj, ReactServerRenderingTransaction, ReactDefaultBatchingStrategy, ReactUpdates, testUtils, redirectLocation, configureReact, renderTree, extractElements, extractRoute, fakeEvent, changeInputs, submitForm, processForm, routeMetadata, resetRedirect, redirect, toString$ = {}.toString;
+  var domUtils, ref$, difference, filter, first, keys, Obj, ReactServerRenderingTransaction, ReactDefaultBatchingStrategy, ReactUpdates, redirectLocation, configureReact, renderTree, fakeEvent, changeInputs, submitForm, processForm, routeMetadata, resetRedirect, redirect;
+  domUtils = require('./virtual-dom-utils');
   ref$ = require('prelude-ls'), difference = ref$.difference, filter = ref$.filter, first = ref$.first, keys = ref$.keys, Obj = ref$.Obj;
   ReactServerRenderingTransaction = require('react/lib/ReactServerRenderingTransaction');
   ReactDefaultBatchingStrategy = require('react/lib/ReactDefaultBatchingStrategy');
   ReactUpdates = require('react/lib/ReactUpdates');
-  testUtils = React.addons.TestUtils;
   redirectLocation = null;
   configureReact = function(){
     ReactDefaultBatchingStrategy.isBatchingUpdates = true;
@@ -25,36 +25,6 @@
       ReactServerRenderingTransaction.release(transaction);
     }
     return instance;
-  };
-  extractElements = function(path, postData, instance){
-    var inputNames, forms, inputs, form;
-    inputNames = keys(postData);
-    forms = testUtils.findAllInRenderedTree(instance, function(it){
-      return it._tag === 'form';
-    });
-    inputs = [];
-    form = find(function(form){
-      inputs = testUtils.findAllInRenderedTree(form, function(it){
-        var ref$;
-        return (ref$ = it._tag) === 'input' || ref$ === 'textarea' || ref$ === 'select';
-      });
-      return any(function(it){
-        return in$(it.props.name, inputNames);
-      })(
-      inputs);
-    })(
-    filter(function(it){
-      return it.props.action === path;
-    })(
-    forms));
-    return [form, inputs];
-  };
-  extractRoute = function(instance){
-    var routes;
-    routes = testUtils.findAllInRenderedTree(instance, function(it){
-      return it.getLayoutTemplate && toString$.call(it.getLayoutTemplate).slice(8, -1) === 'Function';
-    });
-    return routes[0];
   };
   fakeEvent = function(element, opts){
     var target, ref$;
@@ -86,11 +56,12 @@
     return ReactUpdates.flushBatchedUpdates();
   };
   processForm = function(rootElement, initialState, postData, path){
-    var instance, ref$, form, inputs, that;
+    var instance, inputNames, ref$, form, inputs, that;
     configureReact();
     resetRedirect();
     instance = renderTree(rootElement);
-    ref$ = extractElements(path, postData, instance), form = ref$[0], inputs = ref$[1];
+    inputNames = keys(postData);
+    ref$ = domUtils.formElements(instance, path, inputNames), form = ref$[0], inputs = ref$[1];
     changeInputs(inputs, postData);
     submitForm(form);
     if (that = redirectLocation) {
@@ -99,15 +70,10 @@
     return null;
   };
   routeMetadata = function(rootElement, initialState){
-    var instance, route, title, that;
+    var instance;
     configureReact();
     instance = renderTree(rootElement, 1);
-    route = extractRoute(instance);
-    title = (that = route.getTitle) ? that() : "";
-    return {
-      title: title,
-      layout: route.getLayoutTemplate()
-    };
+    return domUtils.routeMetadata(instance);
   };
   resetRedirect = function(){
     return redirectLocation = null;
@@ -120,9 +86,4 @@
     processForm: processForm,
     redirect: redirect
   };
-  function in$(x, xs){
-    var i = -1, l = xs.length >>> 0;
-    while (++i < l) if (x === xs[i]) return true;
-    return false;
-  }
 }).call(this);

--- a/lib/server-rendering.js
+++ b/lib/server-rendering.js
@@ -1,5 +1,5 @@
 (function(){
-  var ref$, difference, filter, first, keys, Obj, ReactServerRenderingTransaction, ReactDefaultBatchingStrategy, ReactUpdates, testUtils, redirectLocation, configureReact, renderTree, extractElements, fakeEvent, changeInputs, submitForm, processForm, resetRedirect, redirect;
+  var ref$, difference, filter, first, keys, Obj, ReactServerRenderingTransaction, ReactDefaultBatchingStrategy, ReactUpdates, testUtils, redirectLocation, configureReact, renderTree, extractElements, extractRoute, fakeEvent, changeInputs, submitForm, processForm, routeMetadata, resetRedirect, redirect, toString$ = {}.toString;
   ref$ = require('prelude-ls'), difference = ref$.difference, filter = ref$.filter, first = ref$.first, keys = ref$.keys, Obj = ref$.Obj;
   ReactServerRenderingTransaction = require('react/lib/ReactServerRenderingTransaction');
   ReactDefaultBatchingStrategy = require('react/lib/ReactDefaultBatchingStrategy');
@@ -11,14 +11,15 @@
     ReactUpdates.injection.injectReconcileTransaction(ReactServerRenderingTransaction);
     return ReactUpdates.injection.injectBatchingStrategy(ReactDefaultBatchingStrategy);
   };
-  renderTree = function(element){
+  renderTree = function(element, depth){
     var transaction, instance;
+    depth == null && (depth = 0);
     transaction = ReactServerRenderingTransaction.getPooled(true);
     instance = new element.type(element.props);
     instance.construct(element);
     try {
       transaction.perform(function(){
-        return instance.mountComponent("canBeAynthingWhee", transaction, 0);
+        return instance.mountComponent("canBeAynthingWhee", transaction, depth);
       });
     } finally {
       ReactServerRenderingTransaction.release(transaction);
@@ -47,6 +48,13 @@
     })(
     forms));
     return [form, inputs];
+  };
+  extractRoute = function(instance){
+    var routes;
+    routes = testUtils.findAllInRenderedTree(instance, function(it){
+      return it.getLayoutTemplate && toString$.call(it.getLayoutTemplate).slice(8, -1) === 'Function';
+    });
+    return routes[0];
   };
   fakeEvent = function(element, opts){
     var target, ref$;
@@ -90,6 +98,17 @@
     }
     return null;
   };
+  routeMetadata = function(rootElement, initialState){
+    var instance, route, title, that;
+    configureReact();
+    instance = renderTree(rootElement, 1);
+    route = extractRoute(instance);
+    title = (that = route.getTitle) ? that() : "";
+    return {
+      title: title,
+      layout: route.getLayoutTemplate()
+    };
+  };
   resetRedirect = function(){
     return redirectLocation = null;
   };
@@ -97,6 +116,7 @@
     return redirectLocation = path;
   };
   module.exports = {
+    routeMetadata: routeMetadata,
     processForm: processForm,
     redirect: redirect
   };

--- a/lib/server.js
+++ b/lib/server.js
@@ -30,11 +30,13 @@
     options = import$(clone$(defaults), options);
     app = options.app || require(options.paths.app.rel);
     get = function(req, res){
+      console.log("GET", req.originalUrl);
       return reflexGet(app, req.originalUrl, options).spread(function(status, headers, body){
         return res.status(status).set(headers).send(body);
       });
     };
     post = function(req, res){
+      console.log("POST", req.originalUrl, req.body);
       return reflexPost(app, req.originalUrl, req.body, options).spread(function(status, headers, body){
         return res.status(status).set(headers).send(body);
       });
@@ -102,7 +104,6 @@
     };
   };
   reflexGet = function(app, url, options){
-    console.log("GET", url);
     return app.render(url).spread(function(meta, appState, body){
       var html;
       html = layoutRender(meta, body, appState, options);
@@ -110,7 +111,6 @@
     });
   };
   reflexPost = function(app, url, postData, options){
-    console.log("POST", req.originalUrl, req.body);
     return app.processForm(url, postData).spread(function(meta, appState, body, location){
       var html;
       if (!body) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,5 +1,5 @@
 (function(){
-  var express, fs, path, jade, bluebird, bodyParser, bundler, LiveScript, register, ref$, each, values, filter, find, flatten, map, first, __template, readFile, defaults, reflexGet, reflexPost, reflexInterp, layoutRender;
+  var express, fs, path, jade, bluebird, bodyParser, bundler, LiveScript, register, ref$, each, values, filter, find, flatten, map, first, defaults, reflexGet, reflexPost, __template, layoutRender;
   express = require('express');
   fs = require('fs');
   path = require('path');
@@ -10,8 +10,6 @@
   LiveScript = require('LiveScript');
   register = require('babel/register');
   ref$ = require('prelude-ls'), each = ref$.each, values = ref$.values, filter = ref$.filter, find = ref$.find, flatten = ref$.flatten, map = ref$.map, first = ref$.first;
-  __template = jade.compileFile(path.join(__dirname, 'index.jade'));
-  readFile = bluebird.promisify(fs.readFile);
   defaults = {
     environment: process.env.NODE_ENV || 'development',
     port: 3000,
@@ -20,7 +18,6 @@
         abs: path.resolve('.'),
         rel: path.relative(__dirname, path.resolve('.'))
       },
-      layouts: 'app/layouts',
       reflex: {
         abs: path.dirname(require.resolve("../package.json")),
         rel: path.relative(path.resolve('.'), path.dirname(require.resolve("../package.json")))
@@ -30,20 +27,15 @@
   };
   module.exports = function(options){
     var app, get, post;
-    options == null && (options = defaults);
+    options = import$(clone$(defaults), options);
     app = options.app || require(options.paths.app.rel);
     get = function(req, res){
-      console.log("GET", req.originalUrl);
-      return reflexGet(app, req.originalUrl, options).then(function(it){
-        return res.send(it);
+      return reflexGet(app, req.originalUrl, options).spread(function(status, headers, body){
+        return res.status(status).set(headers).send(body);
       });
     };
     post = function(req, res){
-      var postData;
-      postData = req.body;
-      console.log("POST", req.originalUrl, postData);
-      return reflexPost(app, req.originalUrl, postData, options).spread(function(status, headers, body){
-        console.log(status + "", headers);
+      return reflexPost(app, req.originalUrl, req.body, options).spread(function(status, headers, body){
         return res.status(status).set(headers).send(body);
       });
     };
@@ -110,44 +102,55 @@
     };
   };
   reflexGet = function(app, url, options){
-    return app.render(url).spread(function(appState, body){
-      return layoutRender(path.join(options.paths.layouts, 'default.html'), body, appState, options);
+    console.log("GET", url);
+    return app.render(url).spread(function(meta, appState, body){
+      var html;
+      html = layoutRender(meta, body, appState, options);
+      return [200, {}, html];
     });
   };
   reflexPost = function(app, url, postData, options){
-    return app.processForm(url, postData).spread(function(appState, body, location){
-      if (body) {
-        return layoutRender(path.join(options.paths.layouts, 'default.html'), body, appState, options).then(function(it){
-          return [200, {}, it];
-        });
-      } else {
-        return bluebird.resolve([
+    console.log("POST", req.originalUrl, req.body);
+    return app.processForm(url, postData).spread(function(meta, appState, body, location){
+      var html;
+      if (!body) {
+        return [
           302, {
             'Location': location
           }, ""
-        ]);
+        ];
       }
+      html = layoutRender(meta, body, appState, options);
+      return [200, {}, html];
     });
   };
-  reflexInterp = function(template, body){
-    return template.toString().replace('{reflex-body}', body);
-  };
-  layoutRender = function(path, body, appState, options){
-    return readFile(path).then(function(template){
-      var bundlePath;
-      bundlePath = options.environment === 'development'
-        ? "http://localhost:3001/app.js"
-        : "/" + options.paths['public'] + "/app.js";
-      return reflexInterp(template, __template({
-        'public': options.paths['public'],
-        bundle: bundlePath,
-        body: body,
-        state: appState
-      }));
-    }).error(function(){
-      throw new Error('Template not found');
+  __template = jade.compileFile(path.join(__dirname, 'index.jade'));
+  layoutRender = function(meta, body, appState, options){
+    var bundlePath, reflexBody, layout, title;
+    bundlePath = options.environment === 'development'
+      ? "http://localhost:3001/app.js"
+      : "/" + options.paths['public'] + "/app.js";
+    reflexBody = __template({
+      'public': options.paths['public'],
+      bundle: bundlePath,
+      body: body,
+      state: appState
+    });
+    layout = meta.layout, title = meta.title;
+    return layout({
+      body: reflexBody,
+      title: title
     });
   };
+  function import$(obj, src){
+    var own = {}.hasOwnProperty;
+    for (var key in src) if (own.call(src, key)) obj[key] = src[key];
+    return obj;
+  }
+  function clone$(it){
+    function fun(){} fun.prototype = it;
+    return new fun;
+  }
   function in$(x, xs){
     var i = -1, l = xs.length >>> 0;
     while (++i < l) if (x === xs[i]) return true;

--- a/lib/virtual-dom-utils.js
+++ b/lib/virtual-dom-utils.js
@@ -1,0 +1,51 @@
+(function(){
+  var testUtils, extractRoute, formElements, routeMetadata, toString$ = {}.toString;
+  testUtils = React.addons.TestUtils;
+  extractRoute = function(tree){
+    var routes;
+    routes = testUtils.findAllInRenderedTree(tree, function(it){
+      return it.getLayoutTemplate && toString$.call(it.getLayoutTemplate).slice(8, -1) === 'Function';
+    });
+    return routes[0];
+  };
+  formElements = function(tree, path, inputNames){
+    var forms, inputs, form;
+    forms = testUtils.findAllInRenderedTree(tree, function(it){
+      return it._tag === 'form';
+    });
+    inputs = [];
+    form = find(function(form){
+      inputs = testUtils.findAllInRenderedTree(form, function(it){
+        var ref$;
+        return (ref$ = it._tag) === 'input' || ref$ === 'textarea' || ref$ === 'select';
+      });
+      return any(function(it){
+        return in$(it.props.name, inputNames);
+      })(
+      inputs);
+    })(
+    filter(function(it){
+      return it.props.action === path;
+    })(
+    forms));
+    return [form, inputs];
+  };
+  routeMetadata = function(tree){
+    var route, title, that;
+    route = extractRoute(tree);
+    title = (that = route.getTitle) ? that() : "";
+    return {
+      title: title,
+      layout: route.getLayoutTemplate()
+    };
+  };
+  module.exports = {
+    routeMetadata: routeMetadata,
+    formElements: formElements
+  };
+  function in$(x, xs){
+    var i = -1, l = xs.length >>> 0;
+    while (++i < l) if (x === xs[i]) return true;
+    return false;
+  }
+}).call(this);

--- a/src/application.ls
+++ b/src/application.ls
@@ -52,7 +52,8 @@ module.exports =
 
         app-state.end-transaction transaction
         .then ->
-          [app-state.deref!, React.render-to-string root-element]
+          meta = server-rendering.route-metadata root-element, app-state
+          [meta, app-state.deref!, React.render-to-string root-element]
 
       # process a form from a particular route and render to string
       # returns a promise of [state, body, location]
@@ -71,7 +72,8 @@ module.exports =
 
         app-state.end-transaction transaction
         .then ->
+          meta = server-rendering.route-metadata root-element, app-state
           body = unless location then React.render-to-string root-element else null
 
-          [app-state.deref!, body, location]
+          [meta, app-state.deref!, body, location]
 

--- a/src/routes.ls
+++ b/src/routes.ls
@@ -1,4 +1,8 @@
-require! <[ page ]>
+require! {
+  './virtual-dom-utils': 'dom-utils'
+  page
+}
+
 {split-at, drop, split, map, pairs-to-obj, each, find} = require 'prelude-ls'
 
 # Split URL into path, query string and hash
@@ -65,10 +69,12 @@ module.exports =
         # FIXME extract the following into a separate function
         context = context-from-url(ctx.canonical-path, ctx.params)
 
-        root-component.set-state component: config.component, context: context
+        root-component.set-state component: config.component, context: context, ->
+          # FIXME update document title based on the config.component
+          {title} = dom-utils.route-metadata root-component
 
-        # FIXME update document title based on the config.component
-        window.scroll-to 0, 0
+          document.title = title
+          window.scroll-to 0, 0
 
         # call the route callback
         config.init(app-state, context) if config.init

--- a/src/routes.ls
+++ b/src/routes.ls
@@ -62,13 +62,16 @@ module.exports =
   start: (configs, root-component, app-state) ->
     configs |> each (config) ->
       page.callbacks.push config.route.middleware (ctx) ->
+        # FIXME extract the following into a separate function
         context = context-from-url(ctx.canonical-path, ctx.params)
 
         root-component.set-state component: config.component, context: context
+
+        # FIXME update document title based on the config.component
         window.scroll-to 0, 0
 
         # call the route callback
-        config.init(app-state, context, ->) if config.init
+        config.init(app-state, context) if config.init
 
     # only start client-side routing if pushState is available
     page.start! if (typeof window.history.replace-state isnt 'undefined')

--- a/src/server.ls
+++ b/src/server.ls
@@ -18,11 +18,13 @@ module.exports = (options) ->
   app = options.app or require options.paths.app.rel
 
   get = (req, res) ->
+    console.log "GET", req.original-url
     reflex-get app, req.original-url, options
     .spread (status, headers, body) ->
       res.status status .set headers .send body
 
   post = (req, res) ->
+    console.log "POST", req.original-url, req.body
     reflex-post app, req.original-url, req.body, options
     .spread (status, headers, body) ->
       res.status status .set headers .send body
@@ -67,14 +69,12 @@ module.exports = (options) ->
   /* end-test-exports */
 
 reflex-get = (app, url, options) ->
-  console.log "GET", url
   app.render url
   .spread (meta, app-state, body) ->
     html = layout-render meta, body, app-state, options
     [200, {}, html]
 
 reflex-post = (app, url, post-data, options) ->
-  console.log "POST", req.original-url, req.body
   app.process-form url, post-data
   .spread (meta, app-state, body, location) ->
     # FIXME build a full URL for location to comply with HTTP

--- a/src/virtual-dom-utils.ls
+++ b/src/virtual-dom-utils.ls
@@ -1,0 +1,35 @@
+test-utils = React.addons.TestUtils
+
+extract-route = (tree) ->
+  routes = test-utils.find-all-in-rendered-tree tree, ->
+    return it.get-layout-template and typeof! it.get-layout-template is 'Function'
+
+  routes[0]
+
+form-elements = (tree, path, input-names) ->
+  forms = test-utils.find-all-in-rendered-tree tree, ->
+    return it._tag is 'form'
+
+  inputs = []
+  form = forms
+  |> filter (.props.action is path)
+  |> find (form) ->
+    inputs := test-utils.find-all-in-rendered-tree form, ->
+      return it._tag in ['input', 'textarea', 'select']
+
+    return (inputs |> any -> it.props.name in input-names)
+
+  [form, inputs]
+
+route-metadata = (tree) ->
+  route = extract-route tree
+
+  title = if route.get-title then that! else ""
+
+  # collect all the metadata
+  title: title
+  layout: route.get-layout-template! # FIXME default layout?
+
+module.exports =
+  route-metadata: route-metadata
+  form-elements: form-elements


### PR DESCRIPTION
This gives us more flexibility in server side rendering and lets the developer change the outer layout of the application on each request handled by the server. It resolves #13.

The way this works is a route component gets extra two API methods - `get-layout-template` and `get-title`. These methods can use `@props` and `@state` since they are called on component instances. 

The `get-layout-template` should return a function which takes a `context` object of the form `{title: "...", body: "..."}` and returns a rendered layout. The idea is that a user would use a template engine to create this function.

The `get-title` returns a title for the current page. On the server, this gets injected into the layout template. On the client, the title will get updated every time a route changes.

Example component:

```
require! <[ reflex ]>
layout-tpl = require '../lib/layout'
layout = reflex.dom require '../components/layout'

d = reflex.DOM

module.exports = React.create-class do
  display-name: 'welcome-page'

  get-layout-template: -> layout-tpl
  get-title: -> "Welcome"

  render: ->
    console.log "Rendering welcome!"
    layout do
      d.h1 null, "Welcome!"
```

# To-Do

- [x] get layout and title from the route component
- [x] render through the layout function
- [x] continuously update the title in the browser