### PR TITLE
Make Cursor.get optimistic (Resolves #37)

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -112,9 +112,6 @@
     var val;
     path = this._path.concat(split('.', path));
     val = this._root._data.getIn(path);
-    if (typeof val === 'undefined') {
-      return null;
-    }
     if (val instanceof Immutable.List) {
       return arrayCursor(this._root, null, val.size, path);
     } else {
@@ -124,6 +121,9 @@
   Cursor.prototype.deref = function(){
     var data;
     data = this.raw();
+    if (typeof data === 'undefined') {
+      return null;
+    }
     if (data && data.toJS) {
       return data.toJS();
     } else {

--- a/spec/cursor_spec.ls
+++ b/spec/cursor_spec.ls
@@ -32,10 +32,13 @@ describe "cursor" (_) ->
 
       expect data.deref!.person.first_name .toBe "John"
 
-    it "returns undefined if the path doesn't exist" ->
+    it "returns an object cursor if the path doesn't exist" ->
       foo = data.get \this.doesnt.exist.at.all
 
-      expect foo .to-be null
+      expect foo .not.to-be null
+      expect foo.deref .not.to-be null
+
+      expect foo.deref! .to-be null
 
   describe "to array" (_) ->
     it "derefs a array item" ->
@@ -123,6 +126,20 @@ describe "cursor" (_) ->
 
       expect (pets.get \0.name .deref!) .toBe "Professor Catus"
       expect (pets.get \1.name .deref!) .toBe "Baron Woofson"
+
+    it "allows updates on paths that previously didn't exist" ->
+      data = cursor raw-data
+      new-thing = data.get \person.weight
+      new-things = data.get \person.flaws
+
+      new-thing.update -> 80
+      new-things.update -> ['rude', 'lazy']
+
+      expect new-thing.deref! .to-be 80
+      expect (data.get \person.weight .deref!) .to-be 80
+
+      expect new-things.deref!.0 .to-be 'rude'
+      expect (data.get \person.flaws.1 .deref!) .to-be 'lazy'
 
   describe "observation" (_) ->
     it "notifies on change to a path" ->

--- a/src/cursor.ls
+++ b/src/cursor.ls
@@ -88,8 +88,6 @@ Cursor.prototype.get = (path) ->
   path = @_path ++ (split '.', path)
   val = @_root._data.get-in path
 
-  return null if typeof val is 'undefined'
-
   # if the resulting object is a list, return array-cursor
   if val instanceof Immutable.List
     array-cursor @_root, null, val.size, path
@@ -98,6 +96,7 @@ Cursor.prototype.get = (path) ->
 
 Cursor.prototype.deref = ->
   data = this.raw!
+  return null if typeof data is 'undefined'
 
   if data and data.toJS then data.toJS! else data
 


### PR DESCRIPTION
Allow calling `.get` on cursors with path that doesn't exist. This has the following semantics:

*  `.deref` returns `null`
*  `.update` allows setting a value for the path
*  `.on-change` will register an observer although the data doesn't exist 

The last item is equivalent to observing on a path which later disappears - since it's children don't exist either, they cannot change and such observer therefore never gets called. We may want eventually implement observer garbage collection, but I leave that for later as I'm not sure when that would become a problem.

One potential issue (not really having to do uniquely with this) is the new cursor is an object cursor. Updating it to to an array changes all future cursors to array cursors, but not the existing one. This is similar to updating an existing object cursor to an array value, but potentially more common. I'm not sure how to solve that, to be honest, but I feel like it may be a larger issue with array cursors being actual arrays - we may want to look into other ways of making them behave like arrays for iteration purposes (which should also be more efficient).