### PR TITLE
Change routing to use app-state

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -1,10 +1,11 @@
 (function(){
-  var bluebird, routes, cursor, dom, serverRendering, span, appComponent, initAppState;
+  var bluebird, routes, cursor, dom, serverRendering, domUtils, span, appComponent, initAppState, observePageChange;
   bluebird = require('bluebird');
   routes = require('./routes');
   cursor = require('./cursor');
   dom = require('./dom');
   serverRendering = require('./server-rendering');
+  domUtils = require('./virtual-dom-utils');
   span = dom.span;
   appComponent = React.createFactory(React.createClass({
     displayName: 'reflex-application',
@@ -36,6 +37,16 @@
       route: routeContext
     });
   };
+  observePageChange = function(rootTree, appState){
+    return appState.get('route').onChange(function(){
+      return setTimeout(function(){
+        var title;
+        title = domUtils.routeMetadata(rootTree).title;
+        document.title = title;
+        return window.scrollTo(0, 0);
+      }, 0);
+    });
+  };
   module.exports = {
     create: function(app){
       return {
@@ -60,7 +71,7 @@
               appState: appState
             });
           });
-          console.log("Starting router...");
+          observePageChange(root, appState);
           return routes.start(app.routes(), appState);
         },
         render: function(path){

--- a/lib/application.js
+++ b/lib/application.js
@@ -1,5 +1,5 @@
 (function(){
-  var bluebird, routes, cursor, dom, serverRendering, span, appComponent;
+  var bluebird, routes, cursor, dom, serverRendering, span, appComponent, initAppState;
   bluebird = require('bluebird');
   routes = require('./routes');
   cursor = require('./cursor');
@@ -10,16 +10,19 @@
     displayName: 'reflex-application',
     getInitialState: function(){
       return {
-        component: this.props.component,
-        context: this.props.context,
-        appState: this.props.initialState
+        appState: this.props.appState
       };
     },
+    lookupComponent: function(){
+      var route;
+      route = this.state.appState.get('route').deref();
+      return routes.getComponent(this.props.routes, route.componentId);
+    },
     render: function(){
-      var that;
-      if (that = this.state.component) {
+      var component, that;
+      component = this.lookupComponent();
+      if (that = component) {
         return React.createElement(that, {
-          context: this.state.context,
           appState: this.state.appState
         });
       } else {
@@ -27,44 +30,50 @@
       }
     }
   }));
+  initAppState = function(initialState, routeContext){
+    return cursor({
+      state: initialState,
+      route: routeContext
+    });
+  };
   module.exports = {
-    create: function(config){
+    create: function(app){
       return {
         start: function(){
-          var path, rootDomNode, serverState, initialState, ref$, routeComponent, context, _, rootElement, root;
+          var path, rootDomNode, serverState, routeSet, context, appState, rootElement, root;
           path = location.pathname + location.search + location.hash;
           rootDomNode = document.getElementById("application");
           serverState = JSON.parse(rootDomNode.getAttribute('data-reflex-app-state'));
-          initialState = cursor(serverState || config.getInitialState());
-          ref$ = routes.resolve(path, config.routes()), routeComponent = ref$[0], context = ref$[1], _ = ref$[2];
+          routeSet = app.routes();
+          context = routes.resolve(routeSet, path);
+          appState = serverState
+            ? cursor(serverState)
+            : initAppState(app.getInitialState(), context);
+          app.start(appState);
           rootElement = appComponent({
-            initialState: initialState,
-            component: routeComponent,
-            context: context
+            appState: appState,
+            routes: routeSet
           });
-          config.start(initialState);
           root = React.render(rootElement, rootDomNode);
-          initialState.onChange(function(){
+          appState.onChange(function(){
             return root.setState({
-              appState: initialState
+              appState: appState
             });
           });
-          return routes.start(config.routes(), root, initialState);
+          console.log("Starting router...");
+          return routes.start(app.routes(), appState);
         },
         render: function(path){
-          var appState, ref$, routeComponent, context, routeInit, rootElement, transaction;
-          appState = cursor(config.getInitialState());
-          ref$ = routes.resolve(path, config.routes()), routeComponent = ref$[0], context = ref$[1], routeInit = ref$[2];
-          rootElement = appComponent({
-            initialState: appState,
-            component: routeComponent,
-            context: context
-          });
+          var routeSet, context, appState, transaction, rootElement;
+          routeSet = app.routes();
+          context = routes.resolve(routeSet, path);
+          appState = initAppState(app.getInitialState(), context);
           transaction = appState.startTransaction();
-          config.start(appState);
-          if (routeInit) {
-            routeInit(appState, context);
-          }
+          app.start(appState);
+          rootElement = appComponent({
+            appState: appState,
+            routes: routeSet
+          });
           return appState.endTransaction(transaction).then(function(){
             var meta;
             meta = serverRendering.routeMetadata(rootElement, appState);
@@ -72,19 +81,16 @@
           });
         },
         processForm: function(path, postData){
-          var appState, ref$, routeComponent, context, routeInit, rootElement, transaction, location;
-          appState = cursor(config.getInitialState());
-          ref$ = routes.resolve(path, config.routes()), routeComponent = ref$[0], context = ref$[1], routeInit = ref$[2];
-          rootElement = appComponent({
-            initialState: appState,
-            component: routeComponent,
-            context: context
-          });
+          var routeSet, context, appState, transaction, rootElement, location;
+          routeSet = app.routes();
+          context = routes.resolve(routeSet, path);
+          appState = initAppState(app.getInitialState(), context);
           transaction = appState.startTransaction();
-          config.start(appState);
-          if (routeInit) {
-            routeInit(appState, context);
-          }
+          app.start(appState);
+          rootElement = appComponent({
+            appState: appState,
+            routes: routeSet
+          });
           location = serverRendering.processForm(rootElement, appState, postData, path);
           return appState.endTransaction(transaction).then(function(){
             var meta, body;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,5 +1,5 @@
 (function(){
-  var domUtils, page, ref$, splitAt, drop, split, map, pairsToObj, each, find, splitUrl, parseQuery, contextFromUrl, slice$ = [].slice;
+  var domUtils, page, ref$, splitAt, drop, split, map, pairsToObj, each, find, splitUrl, parseQuery, componentId, contextFromUrl, slice$ = [].slice;
   domUtils = require('./virtual-dom-utils');
   page = require('page');
   ref$ = require('prelude-ls'), splitAt = ref$.splitAt, drop = ref$.drop, split = ref$.split, map = ref$.map, pairsToObj = ref$.pairsToObj, each = ref$.each, find = ref$.find;
@@ -32,11 +32,15 @@
     split("&")(
     query)));
   };
-  contextFromUrl = function(url, params){
+  componentId = function(route){
+    return route.pattern;
+  };
+  contextFromUrl = function(url, route, params){
     var ref$, path, qs, hash, query;
     ref$ = splitUrl(url), path = ref$[0], qs = ref$[1], hash = ref$[2];
     query = parseQuery(qs);
     return {
+      componentId: componentId(route),
       canonicalPath: url,
       path: path,
       queryString: qs,
@@ -50,60 +54,73 @@
     define: function(){
       var configs;
       configs = slice$.call(arguments);
-      return configs;
-    },
-    page: function(pattern, componentClass, init){
       return {
+        routes: configs,
+        components: pairsToObj(
+        map(function(it){
+          return [componentId(it), it.component];
+        })(
+        configs))
+      };
+    },
+    page: function(pattern, componentClass){
+      return {
+        pattern: pattern,
         route: new page.Route(pattern),
-        component: componentClass,
-        init: 'function' === typeof init ? init : void 8
+        component: componentClass
       };
     },
     navigate: function(path){
       return page.show(path);
     },
-    start: function(configs, rootComponent, appState){
-      each(function(config){
-        return page.callbacks.push(config.route.middleware(function(ctx){
+    start: function(routeSet, appState){
+      each(function(route){
+        return page.callbacks.push(route.route.middleware(function(ctx){
           var context;
-          context = contextFromUrl(ctx.canonicalPath, ctx.params);
-          rootComponent.setState({
-            component: config.component,
-            context: context
-          }, function(){
-            var title;
-            title = domUtils.routeMetadata(rootComponent).title;
-            document.title = title;
-            return window.scrollTo(0, 0);
+          context = contextFromUrl(ctx.canonicalPath, route, ctx.params);
+          return appState.get('route').update(function(){
+            return context;
           });
-          if (config.init) {
-            return config.init(appState, context);
-          }
         }));
       })(
-      configs);
+      routeSet.routes);
       if (typeof window.history.replaceState !== 'undefined') {
         page.start();
       }
       return this.running = true;
     },
-    resolve: function(url, config){
-      var params, route, context;
+    resolve: function(routeSet, url){
+      var params, route;
       params = [];
       route = find(function(it){
         return it.route.match(url, params);
       })(
-      config);
+      routeSet.routes);
       if (!route) {
-        return [null];
+        return null;
       }
-      context = contextFromUrl(url, params);
-      return [route.component, context, route.init];
-    }
+      return contextFromUrl(url, route, params);
+    },
+    getComponent: curry$(function(routeSet, componentId){
+      return routeSet.components[componentId];
+    })
   };
   function import$(obj, src){
     var own = {}.hasOwnProperty;
     for (var key in src) if (own.call(src, key)) obj[key] = src[key];
     return obj;
+  }
+  function curry$(f, bound){
+    var context,
+    _curry = function(args) {
+      return f.length > 1 ? function(){
+        var params = args ? args.concat() : [];
+        context = bound ? context || this : this;
+        return params.push.apply(params, arguments) <
+            f.length && arguments.length ?
+          _curry.call(context, params) : f.apply(context, params);
+      } : f;
+    };
+    return _curry();
   }
 }).call(this);

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,6 +1,5 @@
 (function(){
-  var domUtils, page, ref$, splitAt, drop, split, map, pairsToObj, each, find, splitUrl, parseQuery, componentId, contextFromUrl, slice$ = [].slice;
-  domUtils = require('./virtual-dom-utils');
+  var page, ref$, splitAt, drop, split, map, pairsToObj, each, find, splitUrl, parseQuery, componentId, contextFromUrl, slice$ = [].slice;
   page = require('page');
   ref$ = require('prelude-ls'), splitAt = ref$.splitAt, drop = ref$.drop, split = ref$.split, map = ref$.map, pairsToObj = ref$.pairsToObj, each = ref$.each, find = ref$.find;
   splitUrl = function(url){

--- a/src/application.ls
+++ b/src/application.ls
@@ -1,4 +1,6 @@
 require! <[ bluebird ./routes ./cursor ./dom ./server-rendering ]>
+require! './virtual-dom-utils': 'dom-utils'
+
 {span} = dom
 
 app-component = React.create-factory React.create-class do
@@ -21,6 +23,19 @@ app-component = React.create-factory React.create-class do
 
 init-app-state = (initial-state, route-context) ->
   cursor state: initial-state, route: route-context
+
+observe-page-change = (root-tree, app-state) ->
+  app-state.get \route .on-change ->
+    # FIXME this is clearly a hack. We should figure out
+    # how to do this when the rendering is done
+    # which is after the set-state on the root component
+    # is done.
+    set-timeout ->
+      {title} = dom-utils.route-metadata root-tree
+
+      document.title = title
+      window.scroll-to 0, 0
+    , 0
 
 module.exports =
   # define an application instance
@@ -47,13 +62,14 @@ module.exports =
 
         # re-render on app-state change
         app-state.on-change -> root.set-state app-state: app-state
+
+        observe-page-change root, app-state
         routes.start app.routes!, app-state
 
       # render a particular route to string
       # returns a promise of [state, body]
       render: (path) ->
         route-set = app.routes!
-
         context = routes.resolve route-set, path
         app-state = init-app-state app.get-initial-state!, context
 
@@ -71,15 +87,15 @@ module.exports =
       # returns a promise of [state, body, location]
       process-form: (path, post-data) ->
         route-set = app.routes!
-
         context = routes.resolve route-set, path
         app-state = init-app-state app.get-initial-state!, context
+
         transaction = app-state.start-transaction!
         app.start app-state
 
         root-element = app-component app-state: app-state, routes: route-set
-        location = server-rendering.process-form root-element, app-state, post-data, path
 
+        location = server-rendering.process-form root-element, app-state, post-data, path
         app-state.end-transaction transaction
         .then ->
           meta = server-rendering.route-metadata root-element, app-state

--- a/src/routes.ls
+++ b/src/routes.ls
@@ -1,7 +1,4 @@
-require! {
-  './virtual-dom-utils': 'dom-utils'
-  page
-}
+require! 'page'
 
 {split-at, drop, split, map, pairs-to-obj, each, find} = require 'prelude-ls'
 
@@ -74,13 +71,6 @@ module.exports =
 
   # Public: start the routing
   start: (route-set, app-state) ->
-    # FIXME do the following in a 'app-state.route' observer
-    # removing the need for root-component to be an argument of this
-    #
-    # {title} = dom-utils.route-metadata root-component
-    # document.title = title
-    # window.scroll-to 0, 0
-
     route-set.routes |> each (route) ->
       page.callbacks.push route.route.middleware (ctx) ->
         context = context-from-url(ctx.canonical-path, route, ctx.params)

--- a/src/routes.ls
+++ b/src/routes.ls
@@ -34,12 +34,16 @@ parse-query = (query) ->
     [key, decodeURIComponent(value)]
   |> pairs-to-obj
 
+component-id = (route) ->
+  route.pattern
+
 # Parse a URL into a context object, including extra parameters if
 # necessary.
-context-from-url = (url, params) ->
+context-from-url = (url, route, params) ->
   [path, qs, hash] = split-url url
   query = parse-query(qs)
 
+  component-id: component-id(route) # for now, probably something else later
   canonical-path: url
   path: path
   query-string: qs
@@ -48,46 +52,55 @@ context-from-url = (url, params) ->
   params: ({} import query) import params
 
 module.exports =
+  # Public: is the client side routing running
   running: false
 
+  # Public: define a route set
+  #
+  # returns an opaque structure with route definitions
   define: (...configs) ->
-    configs
+    routes: configs
+    components: (configs |> map (-> [component-id(it), it.component]) |> pairs-to-obj)
 
-  page: (pattern, component-class, init) ->
-    # uses page.js Route to match and resolve routes
-
-    route: new page.Route pattern
+  # Public: declare a route matching a pattern to a component class
+  page: (pattern, component-class) ->
+    pattern: pattern # used as a route key
+    route: new page.Route pattern  # use page.js Route to match and resolve routes
     component: component-class
-    init: if 'function' is typeof init then init
 
+  # Public: explicitly change the current route
   navigate: (path) ->
     page.show path
 
-  start: (configs, root-component, app-state) ->
-    configs |> each (config) ->
-      page.callbacks.push config.route.middleware (ctx) ->
-        # FIXME extract the following into a separate function
-        context = context-from-url(ctx.canonical-path, ctx.params)
+  # Public: start the routing
+  start: (route-set, app-state) ->
+    # FIXME do the following in a 'app-state.route' observer
+    # removing the need for root-component to be an argument of this
+    #
+    # {title} = dom-utils.route-metadata root-component
+    # document.title = title
+    # window.scroll-to 0, 0
 
-        root-component.set-state component: config.component, context: context, ->
-          # FIXME update document title based on the config.component
-          {title} = dom-utils.route-metadata root-component
+    route-set.routes |> each (route) ->
+      page.callbacks.push route.route.middleware (ctx) ->
+        context = context-from-url(ctx.canonical-path, route, ctx.params)
 
-          document.title = title
-          window.scroll-to 0, 0
-
-        # call the route callback
-        config.init(app-state, context) if config.init
+        # Put the new route on the app state
+        app-state.get \route .update -> context
 
     # only start client-side routing if pushState is available
     page.start! if (typeof window.history.replace-state isnt 'undefined')
     @running = true
 
-  resolve: (url, config) ->
+  # Public: Resolve a given url to a context based on a route set
+  resolve: (route-set, url) ->
     params = []
-    route = config |> find -> it.route.match url, params
+    route = route-set.routes |> find -> it.route.match url, params
+    return null unless route
 
-    return [null] unless route
+    context-from-url url, route, params
 
-    context  = context-from-url url, params
-    [route.component, context, route.init]
+  # Public: lookup a component for a route in the route set
+  get-component: (route-set, component-id) -->
+    # this is a function on routes for forward compatibility
+    route-set.components[component-id]

--- a/src/routes.ls
+++ b/src/routes.ls
@@ -31,6 +31,7 @@ parse-query = (query) ->
     [key, decodeURIComponent(value)]
   |> pairs-to-obj
 
+# Get a unique key for a component from a route definition
 component-id = (route) ->
   route.pattern
 
@@ -91,6 +92,6 @@ module.exports =
     context-from-url url, route, params
 
   # Public: lookup a component for a route in the route set
+  # this is a function on routes for forward compatibility
   get-component: (route-set, component-id) -->
-    # this is a function on routes for forward compatibility
     route-set.components[component-id]


### PR DESCRIPTION
This profoundly changes the way routes are handled. Previously
routes update was handled separately from app-state update by
calling setState on the root component.

Now instead the router updates the app-state with the context of
the resolved route and the root component gets re-rendered automatically.

This has a number of benefits, namely it removes the need for route
initialisers, which can now simply be state observers (and as such, they
can be asynchronous and still work isomorphically). It also decouples
routing from the application module even more.

## Todo

- [x] use app state for routing
- [x] fix title updates and scroll to top behaviour
- [x] clean up `application.ls`