### PR TITLE
Added instructions to link reflex as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ That gets you the three pieces, next we need to link `generator-reflex` and `ref
 
 ```
 $ cd generator-reflex && npm link
-$ cd .. && cd reflex-cli
-$ npm link generator-reflex
+$ cd .. && cd reflex && npm link
+$ cd .. && cd reflex-cli
+$ npm link reflex generator-reflex
 $ npm link
 ```
 


### PR DESCRIPTION
I've updated the readme instructions as it turns out I had to `npm link reflex` into `reflex-cli` before calling `reflex init`.

```
/Users/chris/Source/GitHub/reflex-cli/node_modules/LiveScript/lib/node.js:39
      throw hackTrace(e, js, filename);
            ^
TypeError: Cannot read property 'reflex-server' of undefined
    at Object.<anonymous> (/Users/chris/Source/GitHub/reflex-cli/lib/serve.ls:12:57)
 8| reflex = require('reflex');
 9| build = require('./build.ls');
10| reflexPath = path.dirname(require.resolve('reflex/package.json'));
11| reflexPkg = require(path.join(reflexPath, 'package.json'));
12+ reflexServerBinary = path.join(reflexPath, reflexPkg.bin['reflex-server']);
13| server = null;
14| defaultOpts = {
15|   daemonise: false,
16|   log: false,
    at Module._compile (module.js:460:26)
    at Object.require.extensions..ls (/Users/chris/Source/GitHub/reflex-cli/node_modules/LiveScript/lib/node.js:36:21)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/chris/Source/GitHub/reflex-cli/cli/serve.ls:3:9)
```