### PR TITLE
Take ARCH_PORT env variable into account

### DIFF
--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -11,7 +11,7 @@
   ref$ = require('prelude-ls'), each = ref$.each, values = ref$.values, filter = ref$.filter, find = ref$.find, flatten = ref$.flatten, map = ref$.map, first = ref$.first;
   defaults = {
     environment: process.env.NODE_ENV || 'development',
-    port: 3000,
+    port: process.env.ARCH_PORT || 3000,
     paths: {
       app: {
         abs: path.resolve('.'),

--- a/src/server/server.ls
+++ b/src/server/server.ls
@@ -10,7 +10,7 @@ require! <[
 
 defaults =
   environment: process.env.NODE_ENV or 'development'
-  port: 3000
+  port: process.env.ARCH_PORT or 3000
   paths:
     app:
       abs: path.resolve '.'


### PR DESCRIPTION
Title pretty much sums it up, this makes `arch-cli`'s `--port` work as expected.
Seems like it already was fixed once in #84 but is now abscent.
